### PR TITLE
Fix creation of missing directories

### DIFF
--- a/brain_brew/utils.py
+++ b/brain_brew/utils.py
@@ -59,9 +59,9 @@ def find_all_files_in_directory(directory, recursive=False):
 
 def create_path_if_not_exists(path):
     dir_name = os.path.dirname(path)
-    if not Path().is_dir():
+    if not Path(dir_name).is_dir():
         logging.warning(f"Creating missing filepath '{dir_name}'")
-        os.makedirs(os.path.dirname(dir_name), exist_ok=True)
+        os.makedirs(dir_name, exist_ok=True)
 
 
 def split_tags(tags_value: str) -> list:


### PR DESCRIPTION
The two issues were that

1. Path() wasn't passed an argument.

2. Running a directory through os.path.dirname() strips the trailing `/`, so running it through os.path.dirname() a second time will return its parent directory, which is obviously not what we want.

(Excessively verbose explanation, since I find paths confusing...)

<hr/>

Without this, in the example case of AUG, if `brain_brew_build/Ultimate Geography_xx/` and `brain_brew_build/Ultimate Geography_xx/media/` did not both exist, `brain-brew builder_files/source_to_anki.yaml` failed.