### PR TITLE
Overrides: NoteModel name, Deck desc

### DIFF
--- a/brain_brew/build_tasks/crowd_anki/headers_to_crowd_anki.py
+++ b/brain_brew/build_tasks/crowd_anki/headers_to_crowd_anki.py
@@ -24,15 +24,12 @@ class HeadersToCrowdAnki:
             rep = cls.Representation(part_id=data)  # Support single string being passed in
 
         return cls(
-            headers_to_read=rep.part_id
+            headers=PartHolder.from_file_manager(rep.part_id).part
         )
 
-    headers_to_read: str
-    headers: Headers = field(init=False)
+    headers: Headers
 
     def execute(self) -> dict:
-        self.headers = PartHolder.from_file_manager(self.headers_to_read).part
-
         headers = self.headers_to_crowd_anki(self.headers.data_without_name)
 
         return headers

--- a/brain_brew/build_tasks/crowd_anki/media_to_crowd_anki.py
+++ b/brain_brew/build_tasks/crowd_anki/media_to_crowd_anki.py
@@ -35,4 +35,4 @@ class MediaGroupToCrowdAnki(YamlRepr):
     parts: List[MediaGroup]
 
     def execute(self, ca_media_folder: str) -> Set[MediaFile]:
-        return save_media_groups_to_location(self.parts, ca_media_folder, True)
+        return save_media_groups_to_location(self.parts, ca_media_folder, True, False)

--- a/brain_brew/build_tasks/crowd_anki/notes_to_crowd_anki.py
+++ b/brain_brew/build_tasks/crowd_anki/notes_to_crowd_anki.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union, List
 
 from brain_brew.build_tasks.crowd_anki.shared_base_notes import SharedBaseNotes
+from brain_brew.build_tasks.overrides.notes_override import NotesOverride
 from brain_brew.configuration.part_holder import PartHolder
 from brain_brew.configuration.representation_base import RepresentationBase
 from brain_brew.interfaces.yamale_verifyable import YamlRepr
@@ -23,7 +24,12 @@ class NotesToCrowdAnki(YamlRepr, SharedBaseNotes):
             sort_order: list(str(), required=False)
             reverse_sort: bool(required=False)
             additional_items_to_add: map(str(), key=str(), required=False)
+            override: include('{NotesOverride.task_name()}', required=False)
         '''
+
+    @classmethod
+    def yamale_dependencies(cls) -> set:
+        return {NotesOverride}
 
     @dataclass
     class Representation(RepresentationBase):
@@ -31,6 +37,7 @@ class NotesToCrowdAnki(YamlRepr, SharedBaseNotes):
         additional_items_to_add: Optional[dict] = field(default_factory=lambda: None)
         sort_order: Optional[List[str]] = field(default_factory=lambda: None)
         reverse_sort: Optional[bool] = field(default_factory=lambda: None)
+        override: Optional[dict] = field(default_factory=lambda: None)
 
     @classmethod
     def from_repr(cls, data: Union[Representation, dict]):
@@ -39,7 +46,8 @@ class NotesToCrowdAnki(YamlRepr, SharedBaseNotes):
             notes_to_read=rep.part_id,
             sort_order=SharedBaseNotes._get_sort_order(rep.sort_order),
             reverse_sort=SharedBaseNotes._get_reverse_sort(rep.reverse_sort),
-            additional_items_to_add=rep.additional_items_to_add or {}
+            additional_items_to_add=rep.additional_items_to_add or {},
+            override=NotesOverride.from_repr(rep.override) if rep.override else None
         )
 
     notes: Notes = field(init=False)
@@ -48,11 +56,15 @@ class NotesToCrowdAnki(YamlRepr, SharedBaseNotes):
     additional_items_to_add: dict
     sort_order: Optional[List[str]] = field(default_factory=lambda: None)
     reverse_sort: Optional[bool] = field(default_factory=lambda: None)
+    override: Optional[NotesOverride] = field(default_factory=lambda: None)
 
     def execute(self, nm_name_to_id: dict) -> List[dict]:
         self.notes = PartHolder.from_file_manager(self.notes_to_read).part
 
         notes = self.notes.get_sorted_notes_copy(sort_by_keys=self.sort_order, reverse_sort=self.reverse_sort)
+
+        if self.override:
+            notes = [self.override.override(note) for note in notes]
 
         note_dicts = [self.note_to_ca_note(note, nm_name_to_id, self.additional_items_to_add) for note in notes]
 

--- a/brain_brew/build_tasks/crowd_anki/notes_to_crowd_anki.py
+++ b/brain_brew/build_tasks/crowd_anki/notes_to_crowd_anki.py
@@ -43,23 +43,20 @@ class NotesToCrowdAnki(YamlRepr, SharedBaseNotes):
     def from_repr(cls, data: Union[Representation, dict]):
         rep: cls.Representation = data if isinstance(data, cls.Representation) else cls.Representation.from_dict(data)
         return cls(
-            notes_to_read=rep.part_id,
+            notes=PartHolder.from_file_manager(rep.part_id).part,
             sort_order=SharedBaseNotes._get_sort_order(rep.sort_order),
             reverse_sort=SharedBaseNotes._get_reverse_sort(rep.reverse_sort),
             additional_items_to_add=rep.additional_items_to_add or {},
             override=NotesOverride.from_repr(rep.override) if rep.override else None
         )
 
-    notes: Notes = field(init=False)
-
-    notes_to_read: str
+    notes: Notes
     additional_items_to_add: dict
     sort_order: Optional[List[str]] = field(default_factory=lambda: None)
     reverse_sort: Optional[bool] = field(default_factory=lambda: None)
     override: Optional[NotesOverride] = field(default_factory=lambda: None)
 
     def execute(self, nm_name_to_id: dict) -> List[dict]:
-        self.notes = PartHolder.from_file_manager(self.notes_to_read).part
 
         notes = self.notes.get_sorted_notes_copy(sort_by_keys=self.sort_order, reverse_sort=self.reverse_sort)
 

--- a/brain_brew/build_tasks/csvs/csvs_generate.py
+++ b/brain_brew/build_tasks/csvs/csvs_generate.py
@@ -32,8 +32,7 @@ class CsvsGenerate(SharedBaseCsvs, TopLevelBuildTask):
     def yamale_dependencies(cls) -> set:
         return {NoteModelMapping, FileMapping}
 
-    notes_to_read: str  # TODO: Accept Multiple Note Parts
-    notes: PartHolder[Notes] = field(default=None)
+    notes: PartHolder[Notes]  # TODO: Accept Multiple Note Parts
 
     @dataclass
     class Representation(SharedBaseCsvs.Representation):
@@ -43,14 +42,12 @@ class CsvsGenerate(SharedBaseCsvs, TopLevelBuildTask):
     def from_repr(cls, data: Union[Representation, dict]):
         rep: cls.Representation = data if isinstance(data, cls.Representation) else cls.Representation.from_dict(data)
         return cls(
-            notes_to_read=rep.notes,
+            notes=PartHolder.from_file_manager(rep.notes),
             file_mappings=rep.get_file_mappings(),
-            note_model_mappings_to_read=rep.note_model_mappings
+            note_model_mappings=dict(*map(cls.map_nmm, rep.note_model_mappings))
         )
 
     def execute(self):
-        self.setup_note_model_mappings()
-        self.notes = PartHolder.from_file_manager(self.notes_to_read)
         self.verify_contents()
 
         notes: List[Note] = self.notes.part.get_sorted_notes_copy(

--- a/brain_brew/build_tasks/csvs/csvs_generate.py
+++ b/brain_brew/build_tasks/csvs/csvs_generate.py
@@ -21,7 +21,7 @@ class CsvsGenerate(SharedBaseCsvs, TopLevelBuildTask):
         return r'generate_csv[s]?'
 
     @classmethod
-    def yamale_schema(cls) -> str:
+    def yamale_schema(cls) -> str:  # TODO: Use NotesOverride here, just as in NotesToCrowdAnki
         return f'''\
             notes: str()
             note_model_mappings: list(include('{NoteModelMapping.task_name()}'))

--- a/brain_brew/build_tasks/csvs/notes_from_csvs.py
+++ b/brain_brew/build_tasks/csvs/notes_from_csvs.py
@@ -45,14 +45,13 @@ class NotesFromCsvs(SharedBaseCsvs, BuildPartTask):
             part_id=rep.part_id,
             save_to_file=rep.save_to_file,
             file_mappings=rep.get_file_mappings(),
-            note_model_mappings_to_read=rep.note_model_mappings
+            note_model_mappings=dict(*map(cls.map_nmm, rep.note_model_mappings))
         )
 
     part_id: str
     save_to_file: Optional[str]
 
     def execute(self):
-        self.setup_note_model_mappings()
         self.verify_contents()
 
         csv_data_by_guid: Dict[str, dict] = {}

--- a/brain_brew/build_tasks/csvs/shared_base_csvs.py
+++ b/brain_brew/build_tasks/csvs/shared_base_csvs.py
@@ -22,15 +22,12 @@ class SharedBaseCsvs:
             return list(map(FileMapping.from_repr, self.file_mappings))
 
     file_mappings: List[FileMapping]
-    note_model_mappings_to_read: List[NoteModelMapping.Representation]
-    note_model_mappings: Dict[str, NoteModelMapping] = field(init=False)
+    note_model_mappings: Dict[str, NoteModelMapping]
 
-    def setup_note_model_mappings(self):
-        def map_nmm(nmm_to_map):
-            nmm = NoteModelMapping.from_repr(nmm_to_map)
-            return nmm.get_note_model_mapping_dict()
-
-        self.note_model_mappings = dict(*map(map_nmm, self.note_model_mappings_to_read))
+    @classmethod
+    def map_nmm(cls, nmm_to_map):
+        nmm = NoteModelMapping.from_repr(nmm_to_map)
+        return nmm.get_note_model_mapping_dict()
 
     def verify_contents(self):
         errors = []

--- a/brain_brew/build_tasks/deck_parts/from_yaml_part.py
+++ b/brain_brew/build_tasks/deck_parts/from_yaml_part.py
@@ -5,7 +5,6 @@ from typing import Union
 from brain_brew.configuration.build_config.build_task import BuildPartTask
 from brain_brew.configuration.part_holder import PartHolder
 from brain_brew.configuration.representation_base import RepresentationBase
-from brain_brew.representation.yaml.headers import Headers
 from brain_brew.representation.yaml.media_group import MediaGroup
 from brain_brew.representation.yaml.note_model import NoteModel
 from brain_brew.representation.yaml.notes import Notes
@@ -50,19 +49,6 @@ class NotesFromYamlPart(FromYamlPartBase):
         return r'notes_from_yaml_part'
 
     part_type = Notes
-
-
-@dataclass
-class HeadersFromYamlPart(FromYamlPartBase, BuildPartTask):
-    @classmethod
-    def task_name(cls) -> str:
-        return r'headers_from_yaml_part'
-
-    @classmethod
-    def task_regex(cls) -> str:
-        return r'header[s]?_from_yaml_part'
-
-    part_type = Headers
 
 
 @dataclass

--- a/brain_brew/build_tasks/deck_parts/headers_from_yaml_part.py
+++ b/brain_brew/build_tasks/deck_parts/headers_from_yaml_part.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Union
+
+from brain_brew.build_tasks.deck_parts.from_yaml_part import FromYamlPartBase
+from brain_brew.build_tasks.overrides.headers_override import HeadersOverride
+from brain_brew.configuration.build_config.build_task import BuildPartTask
+from brain_brew.configuration.part_holder import PartHolder
+from brain_brew.configuration.representation_base import RepresentationBase
+from brain_brew.representation.yaml.headers import Headers
+
+
+@dataclass
+class HeadersFromYamlPart(BuildPartTask):
+    @classmethod
+    def yamale_schema(cls) -> str:
+        return f'''\
+            part_id: str()
+            file: str()
+            override: include('{HeadersOverride.task_name()}', required=False)
+        '''
+
+    @classmethod
+    def yamale_dependencies(cls) -> set:
+        return {HeadersOverride}
+
+    @classmethod
+    def task_name(cls) -> str:
+        return r'headers_from_yaml_part'
+
+    @classmethod
+    def task_regex(cls) -> str:
+        return r'header[s]?_from_yaml_part'
+
+    @dataclass
+    class Representation(RepresentationBase):
+        part_id: str
+        file: str
+        override: dict
+
+    @classmethod
+    def from_repr(cls, data: Union[Representation, dict]):
+        rep: cls.Representation = data if isinstance(data, cls.Representation) else cls.Representation.from_dict(data)
+
+        return cls(
+            headers=PartHolder.override_or_create(
+                part_id=rep.part_id,
+                save_to_file=None,
+                part=Headers.from_yaml_file(rep.file)
+            ).part,
+            override=HeadersOverride.from_repr(rep.override)
+        )
+
+    headers: Headers
+    override: HeadersOverride
+
+    def execute(self):
+        if self.override:
+            self.headers = self.override.override(self.headers)

--- a/brain_brew/build_tasks/deck_parts/media_group_to_folder.py
+++ b/brain_brew/build_tasks/deck_parts/media_group_to_folder.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Union, Optional
 
 from brain_brew.configuration.build_config.build_task import BuildPartTask
@@ -24,13 +24,15 @@ class MediaGroupsToFolder(BuildPartTask):
             parts: list(str())
             folder: str()
             clear_folder: bool(required=False)
+            recursive: bool(required=False)
         '''
 
     @dataclass
     class Representation(RepresentationBase):
         parts: List[str]
         folder: str
-        clear_folder: Optional[bool]
+        clear_folder: Optional[bool] = field(default=None)
+        recursive: Optional[bool] = field(default=None)
 
     @classmethod
     def from_repr(cls, data: Union[Representation, dict]):
@@ -38,12 +40,14 @@ class MediaGroupsToFolder(BuildPartTask):
         return cls(
             parts=list(holder.part for holder in map(PartHolder.from_file_manager, rep.parts)),
             folder=rep.folder,
-            clear_folder=rep.clear_folder or False
+            clear_folder=rep.clear_folder or False,
+            recursive=rep.recursive or False
         )
 
     parts: List[MediaGroup]
     folder: str
     clear_folder: bool
+    recursive: bool
 
     def execute(self):
-        save_media_groups_to_location(self.parts, self.folder, self.clear_folder)
+        save_media_groups_to_location(self.parts, self.folder, self.clear_folder, self.recursive)

--- a/brain_brew/build_tasks/deck_parts/note_model_template_from_html_files.py
+++ b/brain_brew/build_tasks/deck_parts/note_model_template_from_html_files.py
@@ -7,7 +7,7 @@ from brain_brew.configuration.representation_base import RepresentationBase
 from brain_brew.representation.generic.html_file import HTMLFile
 from brain_brew.representation.yaml.note_model_template import Template
 
-html_separator = '--'
+html_separator = '\n\n--\n\n'
 
 
 @dataclass
@@ -74,7 +74,7 @@ class TemplateFromHTML(BuildPartTask):
 
             browser_front, browser_back = tuple(browser_data.split(html_separator, maxsplit=1))
         else:
-            browser_front = browser_back = None
+            browser_front = browser_back = ""
 
         template = Template(
             name=self.template_name,

--- a/brain_brew/build_tasks/overrides/headers_override.py
+++ b/brain_brew/build_tasks/overrides/headers_override.py
@@ -3,36 +3,37 @@ from typing import Optional, Union
 
 from brain_brew.configuration.representation_base import RepresentationBase
 from brain_brew.interfaces.yamale_verifyable import YamlRepr
-from brain_brew.representation.yaml.notes import Notes, Note
+from brain_brew.representation.generic.html_file import HTMLFile
+from brain_brew.representation.yaml.headers import Headers
 
 
 @dataclass
-class NotesOverride(YamlRepr):
+class HeadersOverride(YamlRepr):
     @classmethod
     def task_name(cls) -> str:
-        return r"notes_override"
+        return r"headers_override"
 
     @classmethod
     def yamale_schema(cls) -> str:
         return f'''\
-            note_model: str(required=False)
+            deck_description_html_file: str(required=False)
         '''
 
     @dataclass
     class Representation(RepresentationBase):
-        note_model: Optional[str]
+        deck_description_html_file: Optional[str]
 
     @classmethod
     def from_repr(cls, data: Union[Representation, dict]):
         rep: cls.Representation = data if isinstance(data, cls.Representation) else cls.Representation.from_dict(data)
         return cls(
-            note_model=rep.note_model
+            deck_desc_html_file=HTMLFile.create_or_get(rep.deck_description_html_file)
         )
 
-    note_model: Optional[str]
+    deck_desc_html_file: Optional[HTMLFile]
 
-    def override(self, note: Note):
-        if self.note_model:
-            note.note_model = self.note_model
+    def override(self, header: Headers):
+        if self.deck_desc_html_file:
+            header.description = self.deck_desc_html_file.get_data(deep_copy=True)
 
-        return note
+        return header

--- a/brain_brew/build_tasks/overrides/notes_override.py
+++ b/brain_brew/build_tasks/overrides/notes_override.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from brain_brew.configuration.representation_base import RepresentationBase
+from brain_brew.interfaces.yamale_verifyable import YamlRepr
+from brain_brew.representation.yaml.notes import Notes, Note
+
+
+@dataclass
+class NotesOverride(YamlRepr):
+    @classmethod
+    def task_name(cls) -> str:
+        return r"notes_override"
+
+    @classmethod
+    def yamale_schema(cls) -> str:
+        return f'''\
+            note_model: str()
+        '''
+
+    @dataclass
+    class Representation(RepresentationBase):
+        note_model: Optional[str]
+
+    @classmethod
+    def from_repr(cls, data: Union[Representation, dict]):
+        rep: cls.Representation = data if isinstance(data, cls.Representation) else cls.Representation.from_dict(data)
+        return cls(
+            note_model=rep.note_model
+        )
+
+    note_model: Optional[str]
+
+    def override(self, note: Note):
+        if self.note_model:
+            note.note_model = self.note_model
+
+        return note

--- a/brain_brew/configuration/build_config/parts_builder.py
+++ b/brain_brew/configuration/build_config/parts_builder.py
@@ -6,8 +6,9 @@ from brain_brew.build_tasks.crowd_anki.media_group_from_crowd_anki import MediaG
 from brain_brew.build_tasks.crowd_anki.note_models_from_crowd_anki import NoteModelsFromCrowdAnki
 from brain_brew.build_tasks.crowd_anki.notes_from_crowd_anki import NotesFromCrowdAnki
 from brain_brew.build_tasks.csvs.notes_from_csvs import NotesFromCsvs
-from brain_brew.build_tasks.deck_parts.from_yaml_part import NotesFromYamlPart, HeadersFromYamlPart, \
-    NoteModelsFromYamlPart, MediaGroupFromYamlPart
+from brain_brew.build_tasks.deck_parts.from_yaml_part import NotesFromYamlPart, NoteModelsFromYamlPart, \
+    MediaGroupFromYamlPart
+from brain_brew.build_tasks.deck_parts.headers_from_yaml_part import HeadersFromYamlPart
 from brain_brew.build_tasks.deck_parts.media_group_from_folder import MediaGroupFromFolder
 from brain_brew.build_tasks.deck_parts.media_group_to_folder import MediaGroupsToFolder
 from brain_brew.build_tasks.deck_parts.note_model_from_html_parts import NoteModelFromHTMLParts

--- a/brain_brew/configuration/build_config/recipe_builder.py
+++ b/brain_brew/configuration/build_config/recipe_builder.py
@@ -75,4 +75,5 @@ class RecipeBuilder(YamlObject, metaclass=ABCMeta):
 
     def execute(self):
         for task in self.tasks:
-            task.execute()
+            if not task.execute_immediately:
+                task.execute()

--- a/brain_brew/representation/json/crowd_anki_export.py
+++ b/brain_brew/representation/json/crowd_anki_export.py
@@ -39,7 +39,7 @@ class CrowdAnkiExport(SourceFile):
         return cls(file_loc)
 
     def find_json_file_in_folder(self):
-        files = glob.glob(self.folder_location + "*.json")
+        files = glob.glob(f"{glob.escape(self.folder_location)}*.json")
 
         if len(files) == 1:
             return files[0]

--- a/brain_brew/representation/json/wrappers_for_crowd_anki.py
+++ b/brain_brew/representation/json/wrappers_for_crowd_anki.py
@@ -7,6 +7,7 @@ CA_MEDIA_FILES = "media_files"
 CA_CHILDREN = "children"
 CA_TYPE = "__type__"
 CA_NAME = "name"
+CA_DESCRIPTION = "desc"
 
 NOTE_MODEL = "note_model_uuid"
 FLAGS = "flags"

--- a/brain_brew/representation/yaml/headers.py
+++ b/brain_brew/representation/yaml/headers.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from brain_brew.representation.json.wrappers_for_crowd_anki import CA_NAME
+from brain_brew.representation.json.wrappers_for_crowd_anki import CA_NAME, CA_DESCRIPTION
 from brain_brew.representation.yaml.yaml_object import YamlObject
 
 
@@ -18,6 +18,14 @@ class Headers(YamlObject):
     @property
     def name(self) -> str:
         return self.data[CA_NAME]
+
+    @property
+    def description(self) -> str:
+        return self.data.get(CA_DESCRIPTION, "")
+
+    @description.setter
+    def description(self, desc: str):
+        self.data[CA_DESCRIPTION] = desc
 
     @property
     def data_without_name(self) -> dict:

--- a/brain_brew/schemas/recipe.yaml
+++ b/brain_brew/schemas/recipe.yaml
@@ -140,11 +140,15 @@ notes_from_yaml_part:
     part_id: str()
     file: str()
 
+notes_override:
+    note_model: str()
+
 notes_to_crowd_anki:
     part_id: str()
     sort_order: list(str(), required=False)
     reverse_sort: bool(required=False)
     additional_items_to_add: map(str(), key=str(), required=False)
+    override: include('notes_override', required=False)
 
 save_media_groups_to_folder:
     parts: list(str())

--- a/brain_brew/schemas/recipe.yaml
+++ b/brain_brew/schemas/recipe.yaml
@@ -54,6 +54,10 @@ headers_from_crowd_anki:
 headers_from_yaml_part:
     part_id: str()
     file: str()
+    override: include('headers_override', required=False)
+
+headers_override:
+    deck_description_html_file: str(required=False)
 
 media_group_from_crowd_anki:
     part_id: str()
@@ -141,7 +145,7 @@ notes_from_yaml_part:
     file: str()
 
 notes_override:
-    note_model: str()
+    note_model: str(required=False)
 
 notes_to_crowd_anki:
     part_id: str()

--- a/brain_brew/schemas/recipe.yaml
+++ b/brain_brew/schemas/recipe.yaml
@@ -158,3 +158,4 @@ save_media_groups_to_folder:
     parts: list(str())
     folder: str()
     clear_folder: bool(required=False)
+    recursive: bool(required=False)

--- a/brain_brew/transformers/media_group_save_to_location.py
+++ b/brain_brew/transformers/media_group_save_to_location.py
@@ -9,19 +9,22 @@ from brain_brew.utils import create_path_if_not_exists
 def save_media_groups_to_location(
         parts: List[MediaGroup],
         folder: str,
-        clear_folder: bool
+        clear_folder: bool,
+        recursive: bool
 ) -> Set[MediaFile]:
 
-    existing_media_group = MediaGroup.from_directory(folder, False)  # TODO: Use recurring?
+    existing_media_group = MediaGroup.from_directory(folder, recursive)
     all_media_group = MediaGroup.from_many(parts)
 
     in_both, to_move, to_delete = all_media_group.compare(existing_media_group)
 
     create_path_if_not_exists(folder)
     for filename, media_file in all_media_group.media_files.items():
-        # if filename in in_both:
-        #    pass  # TODO: Check if copying is needed?
-        media_file.copy_self_to_target(folder)
+        if filename in in_both:
+            media_file.copy_self_to_target(existing_media_group.media_files[filename].file_path)
+            # TODO: Check if copying is needed?
+        elif filename in to_move:
+            media_file.copy_self_to_target(folder)
 
     if clear_folder and to_delete:
         deleted = '\n'.join(to_delete)


### PR DESCRIPTION
Notes can now be given an override for their notemodel, on write of CrowdAnki. This is useful if you want to make multiple decks with the same notes, but different models.

Similarly Headers can be given an override of a html file to use as their description.

Media saving can now maintain the location of existing items inside subfolders when "recursive" is true.