### PR TITLE
Tsv Support

### DIFF
--- a/brain_brew/commands/argument_reader.py
+++ b/brain_brew/commands/argument_reader.py
@@ -59,6 +59,20 @@ class BBArgumentReader(ArgumentParser):
             type=str,
             help="The folder that stores the CrowdAnki files to build this repo from"
         )
+        parser_init.add_argument(
+            '--delimiter',
+            dest='delimiter',
+            action='store',
+            help="Set the delimiter for Csv files to specific character",
+            type=str
+        )
+        parser_init.add_argument(
+            "--delimitertab", "--tab",
+            action="store_true",
+            dest="delimiter_tab",
+            default=False,
+            help="Use tabs as the delimiter for Csv files"
+        )
 
     def get_parsed(self, override_args=None) -> Command:
         parsed_args = self.parse_args(args=override_args)
@@ -78,9 +92,12 @@ class BBArgumentReader(ArgumentParser):
         if parsed_args.command == Commands.INIT_REPO.value:
             # Required
             crowdanki_folder = parsed_args.crowdanki_folder
+            delimiter = parsed_args.delimiter
+            delimiter_tab = parsed_args.delimiter_tab
 
             return InitRepo(
-                crowdanki_folder=crowdanki_folder
+                crowdanki_folder=crowdanki_folder,
+                delimiter="\t" if delimiter_tab else delimiter
             )
 
         raise KeyError("Unknown Command")

--- a/brain_brew/commands/init_repo/init_repo.py
+++ b/brain_brew/commands/init_repo/init_repo.py
@@ -45,6 +45,7 @@ LOC_MEDIA = "src/media/"
 @dataclass
 class InitRepo(Command):
     crowdanki_folder: str
+    delimiter: str
 
     def execute(self):
         self.setup_repo_structure()
@@ -71,13 +72,14 @@ class InitRepo(Command):
 
         for model in note_models:
             if model.name in used_note_models_in_notes:
-                csv_file_path = os.path.join(LOC_DATA, CsvFile.to_filename_csv(model.name))
+                csv_file_path = os.path.join(LOC_DATA, CsvFile.to_filename_csv(model.name, self.delimiter))
                 column_headers = ["guid"] + model.field_names_lowercase + ["tags"]
-                CsvFile.create_file_with_headers(csv_file_path, column_headers)
+                CsvFile.create_file_with_headers(csv_file_path, column_headers, delimiter=self.delimiter)
 
                 file_mappings.append(FileMapping.Representation(
                     file=csv_file_path,
-                    note_model=model.name
+                    note_model=model.name,
+                    delimiter=self.delimiter
                 ))
 
                 csv_files.append(csv_file_path)
@@ -146,7 +148,7 @@ class InitRepo(Command):
         dp_builder = PartsBuilder(build_part_tasks)
 
         generate_guids_in_csv = GenerateGuidsInCsvs.from_repr(GenerateGuidsInCsvs.Representation(
-            source=csv_files, columns=["guid"]
+            source=csv_files, columns=["guid"], delimiter=self.delimiter
         ))
 
         generate_crowdanki = CrowdAnkiGenerate.from_repr(CrowdAnkiGenerate.Representation(

--- a/brain_brew/configuration/representation_base.py
+++ b/brain_brew/configuration/representation_base.py
@@ -20,8 +20,7 @@ class RepresentationBase:
     def encode(self):
         return {key: value for key, value in self.__dict__.items() if self.encode_filter(key, value)}
 
-    @classmethod
-    def encode_filter(cls, key, value):
+    def encode_filter(self, key, value):
         if value is None:
             return False
         if not value:

--- a/brain_brew/front_matter.py
+++ b/brain_brew/front_matter.py
@@ -1,2 +1,2 @@
 def latest_version_number():
-    return "0.3.5"
+    return "0.3.6"

--- a/brain_brew/schemas/recipe.yaml
+++ b/brain_brew/schemas/recipe.yaml
@@ -41,6 +41,7 @@ generate_csvs:
 generate_guids_in_csvs:
     source: any(str(), list(str()))
     columns: any(str(), list(str()))
+    delimiter: str(required=False)
 
 save_media_groups_to_folder:
     parts: list(str())
@@ -63,6 +64,7 @@ file_mapping:
     reverse_sort: bool(required=False)
     case_insensitive_sort: bool(required=False)
     derivatives: list(include('file_mapping'), required=False)
+    delimiter: str(required=False)
 
 headers_from_crowd_anki:
     part_id: str()

--- a/tests/representation/generic/test_csv_file.py
+++ b/tests/representation/generic/test_csv_file.py
@@ -1,37 +1,59 @@
 import pytest
 
 from brain_brew.representation.generic.csv_file import CsvFile
+from tests.test_file_manager import get_new_file_manager
 from tests.test_files import TestFiles
+
+get_new_file_manager()
 
 
 @pytest.fixture()
 def csv_test1():
-    return CsvFile(TestFiles.CsvFiles.TEST1)
+    csv = CsvFile(TestFiles.CsvFiles.TEST1)
+    csv.read_file()
+    return csv
+
+
+@pytest.fixture()
+def tsv_test1():
+    tsv = CsvFile(TestFiles.TsvFiles.TEST1, delimiter='\t')
+    tsv.read_file()
+    return tsv
 
 
 @pytest.fixture()
 def csv_test1_split1():
-    return CsvFile(TestFiles.CsvFiles.TEST1_SPLIT1)
+    csv = CsvFile(TestFiles.CsvFiles.TEST1_SPLIT1)
+    csv.read_file()
+    return csv
 
 
 @pytest.fixture()
 def csv_test1_split2():
-    return CsvFile(TestFiles.CsvFiles.TEST1_SPLIT2)
+    csv = CsvFile(TestFiles.CsvFiles.TEST1_SPLIT2)
+    csv.read_file()
+    return csv
 
 
 @pytest.fixture()
 def csv_test2():
-    return CsvFile(TestFiles.CsvFiles.TEST2)
+    csv = CsvFile(TestFiles.CsvFiles.TEST2)
+    csv.read_file()
+    return csv
 
 
 @pytest.fixture()
 def csv_test3():
-    return CsvFile(TestFiles.CsvFiles.TEST3)
+    csv = CsvFile(TestFiles.CsvFiles.TEST3)
+    csv.read_file()
+    return csv
 
 
 @pytest.fixture()
 def csv_test2_missing_guids():
-    return CsvFile(TestFiles.CsvFiles.TEST2_MISSING_GUIDS)
+    csv = CsvFile(TestFiles.CsvFiles.TEST2_MISSING_GUIDS)
+    csv.read_file()
+    return csv
 
 
 @pytest.fixture()
@@ -39,50 +61,57 @@ def temp_csv_test1(tmpdir, csv_test1) -> CsvFile:
     file = tmpdir.mkdir("json").join("file.csv")
     file.write("blank")
 
-    return CsvFile.create_or_get(file.strpath)
+    csv = CsvFile.create_or_get(file.strpath)
+    csv.read_file()
+    return csv
 
 
-# class TestConstructor:
-#     def test_runs(self, csv_test1):
-#         assert isinstance(csv_test1, CsvFile)
-#         assert csv_test1.file_location == TestFiles.CsvFiles.TEST1
-#         assert "guid" in csv_test1.column_headers
-#
-#
-# def test_to_filename_csv():
-#     expected = "read-this-file.csv"
-#
-#     assert expected == CsvFile.to_filename_csv("read this file")
-#     assert expected == CsvFile.to_filename_csv("read-this-file")
-#     assert expected == CsvFile.to_filename_csv("read-this-file.csv")
-#     assert expected == CsvFile.to_filename_csv("read          this        file")
-#
-#
-# class TestWriteFile:
-#     def test_runs(self, temp_csv_test1: CsvFile, csv_test1: CsvFile):
-#         temp_csv_test1.write_file()
-#         temp_csv_test1.read_file()
-#
-#         assert temp_csv_test1.get_data() == csv_test1.get_data()
-#
+class TestConstructor:
+    def test_runs(self, csv_test1):
+        assert isinstance(csv_test1, CsvFile)
+        assert csv_test1.file_location == TestFiles.CsvFiles.TEST1
+        assert "guid" in csv_test1.column_headers
 
-# class TestSortData:
-#     @pytest.mark.parametrize("columns, reverse, result_column, expected_results", [
-#         (["guid"], False, "guid", [(0, "AAAA"), (1, "BBBB"), (2, "CCCC"), (14, "OOOO")]),
-#         (["guid"], True, "guid", [(14, "AAAA"), (13, "BBBB"), (12, "CCCC"), (0, "OOOO")]),
-#         (["english"], False, "english", [(0, "banana"), (1, "bird"), (2, "cat"), (14, "you")]),
-#         (["english"], True, "english", [(14, "banana"), (13, "bird"), (12, "cat"), (0, "you")]),
-#         (["tags"], False, "tags", [(0, "besttag"), (1, "funny"), (2, "tag2 tag3"), (13, ""), (14, "")]),
-#         (["esperanto", "english"], False, "esperanto", [(0, "banano"), (1, "birdo"), (6, "vi"), (14, "")]),
-#         (["esperanto", "guid"], False, "guid", [(7, "BBBB"), (14, "LLLL")]),
-#     ])
-#     def test_sort(self, csv_test1: CsvFile, columns, reverse, result_column, expected_results):
-#         csv_test1.sort_data(columns, reverse)
-#
-#         sorted_data = csv_test1.get_data()
-#
-#         for result in expected_results:
-#             assert sorted_data[result[0]][result_column] == result[1]
-#
-#     def test_insensitive(self):
-#         pass
+
+def test_to_filename_csv():
+    assert "read-this-file.csv" == CsvFile.to_filename_csv("read-this-file")
+    assert "read-this-file.csv" == CsvFile.to_filename_csv("read-this-file.csv")
+    assert "read-this-file.tsv" == CsvFile.to_filename_csv("read-this-file.tsv")
+
+
+class TestWriteFile:
+    def test_runs(self, temp_csv_test1: CsvFile, csv_test1: CsvFile):
+        temp_csv_test1.set_data(csv_test1.get_data())
+        temp_csv_test1.write_file()
+        temp_csv_test1.read_file()
+
+        assert temp_csv_test1.get_data() == csv_test1.get_data()
+
+    def test_tsv_same_data(self, temp_csv_test1: CsvFile, tsv_test1: CsvFile):
+        temp_csv_test1.set_data(tsv_test1.get_data())
+        temp_csv_test1.write_file()
+        temp_csv_test1.read_file()
+
+        assert temp_csv_test1.get_data() == tsv_test1.get_data()
+
+
+class TestSortData:
+    @pytest.mark.parametrize("columns, reverse, result_column, expected_results", [
+        (["guid"], False, "guid", [(0, "AAAA"), (1, "BBBB"), (2, "CCCC"), (14, "OOOO")]),
+        (["guid"], True, "guid", [(14, "AAAA"), (13, "BBBB"), (12, "CCCC"), (0, "OOOO")]),
+        (["english"], False, "english", [(0, "banana"), (1, "bird"), (2, "cat"), (14, "you")]),
+        (["english"], True, "english", [(14, "banana"), (13, "bird"), (12, "cat"), (0, "you")]),
+        (["tags"], False, "tags", [(0, "besttag"), (1, "funny"), (2, "tag2 tag3"), (13, ""), (14, "")]),
+        (["esperanto", "english"], False, "esperanto", [(0, "banano"), (1, "birdo"), (6, "vi"), (14, "")]),
+        (["esperanto", "guid"], False, "guid", [(7, "BBBB"), (14, "LLLL")]),
+    ])
+    def test_sort(self, csv_test1: CsvFile, columns, reverse, result_column, expected_results):
+        csv_test1.sort_data(columns, reverse, case_insensitive_sort=True)
+
+        sorted_data = csv_test1.get_data()
+
+        for result in expected_results:
+            assert sorted_data[result[0]][result_column] == result[1]
+
+    def test_insensitive(self):
+        pass

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -46,6 +46,11 @@ class TestFiles:
         TEST2_MISSING_GUIDS = LOC + "test2_missing_guids.csv"
         TEST3 = LOC + "test3.csv"
 
+    class TsvFiles:
+        LOC = "tests/test_files/tsv/"
+
+        TEST1 = LOC + "test1.tsv"
+
     class CrowdAnkiExport:
         LOC = "tests/test_files/crowd_anki/"
 

--- a/tests/test_files/tsv/test1.tsv
+++ b/tests/test_files/tsv/test1.tsv
@@ -1,0 +1,16 @@
+guid	English	Danish	Esperanto	Danish Audio	Esperanto Audio	Japanese	Tags
+AAAA	you	du	vi	[sound:pronunciation_da_du.mp3]			funny
+BBBB	healthy	rask				test	tag2 tag3
+CCCC	tired	træt					besttag
+DDDD	banana	en banan	banano	[sound:pronunciation_da_banan.mp3]			
+EEEE	cat	en kat					
+FFFF	dog	en hund	hundo				
+GGGG	fish	en fisk					
+HHHH	bird	en fugl	birdo				
+IIII	cow	en ko					
+JJJJ	pig	et svin					
+KKKK	mouse	en mus					
+LLLL	horse	en hest					
+MMMM	to learn	at lære	lerni	[sound:pronunciation_da_lære.mp3]			
+NNNN	to eat	at spise	manĝi				
+OOOO	to drink	at drikke	drinki				


### PR DESCRIPTION
Implements the request in: https://github.com/ohare93/brain-brew/discussions/34

New functionality: 
- Delimiters can be specified for each csv file
- `Init` Repo functionality can now take the optional argument `--delimiter [X]" or "--delimitertab" (as "\t" was very difficult for command line to understand :sweat_smile: got a lot of "\\\t"s )
    - The recipe to contain the delimiter, under `file_mapping` and `generate_guids_in_csv`
    - The file type will be changed to `.tsv` if the delimiter is a tab
    - The delimiter will not be overwritten for `.csv` and ",", as well as `.tsv` and "\t"


@boydkelly I have attached the wheel install file, you can install it locally with `pip install folderitisin/Brain_Brew-0.3.6-py3-none-any.whl`
[Brain_Brew-0.3.6.zip](https://github.com/ohare93/brain-brew/files/6759953/Brain_Brew-0.3.6.zip)

If all is well, I will release this new version