### PR TITLE
fix: Allow different types of EOL in note model template regex

### DIFF
--- a/brain_brew/representation/yaml/note_model_template.py
+++ b/brain_brew/representation/yaml/note_model_template.py
@@ -23,7 +23,7 @@ SCRATCH_PAD = AnkiField("scratchPad", "scratch_pad", default_value=0)
 HTML_FILE = AnkiField("html_file")
 BROWSER_HTML_FILE = AnkiField("browser_html_file", default_value=None)
 
-html_separator_regex = r'[(\r\n|\r|\n)]{1,}[-]{1,}[(\r\n|\r|\n)]{1,}'
+html_separator_regex = r'(?:\r\n|\r|\n){1,}[-]{1,}(?:\r\n|\r|\n){1,}'
 
 
 @dataclass

--- a/brain_brew/representation/yaml/note_model_template.py
+++ b/brain_brew/representation/yaml/note_model_template.py
@@ -23,7 +23,7 @@ SCRATCH_PAD = AnkiField("scratchPad", "scratch_pad", default_value=0)
 HTML_FILE = AnkiField("html_file")
 BROWSER_HTML_FILE = AnkiField("browser_html_file", default_value=None)
 
-html_separator_regex = r'[\n]{1,}[-]{1,}[\n]{1,}'
+html_separator_regex = r'[(\r\n|\r|\n)]{1,}[-]{1,}[(\r\n|\r|\n)]{1,}'
 
 
 @dataclass


### PR DESCRIPTION
As reported in #51, the current regex doesn't work on Windows. I adapted the regex to allow `\r\n`, `\n` and `\r`.